### PR TITLE
Update Send-GhostImage to use PS Core Invoke-RequestMethod Form Data …

### DIFF
--- a/PSGhost.psd1
+++ b/PSGhost.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'PSGhost.psm1'
-    ModuleVersion     = '*'
+    ModuleVersion     = '1.0.0'
     GUID              = '3b4869fa-45a9-41a1-a412-bd07c84559dc'
     Author            = 'Adam Bertram'
     CompanyName       = 'Adam the Automator, LLC'

--- a/Public/Send-GhostImage.ps1
+++ b/Public/Send-GhostImage.ps1
@@ -13,30 +13,18 @@ function Send-GhostImage {
         Set-GhostSession
     }
 
-    $fileBytes = [System.IO.File]::ReadAllBytes($FilePath);
-    $fileEnc = [System.Text.Encoding]::GetEncoding('ISO-8859-1').GetString($fileBytes);
-    $boundary = [System.Guid]::NewGuid().ToString(); 
-    $LF = "`r`n";
-
-    $fileName = (Get-Item -Path $FilePath).Name
-    $body = ( 
-        "--$boundary",
-        "Content-Disposition: form-data; name=`"file`"; filename=`"$fileName`"",
-        "Content-Type: application/octet-stream$LF",
-        # $fileEnc,
-        "--$boundary--$LF" 
-    ) -join $LF
-
     $config = Get-GhostConfiguration
-    $invParams = @{
+
+    $Params = @{
         'Method'      = 'POST'
-        'ContentType' = "multipart/form-data; boundary=`"$boundary`""
-        'Uri'         = "$($config.ApiUrl)/ghost/api/v2/admin/images/upload"
-        'Headers'     = @{ 'Origin' = $config.ApiUrl }
-        'Body'        = $body
-        'WebSession'  = $script:ghostSession
+        'Uri'         = "$($config.ApiUrl)/ghost/api/v2/admin/images/upload/"
+        'Form'        = @{
+            "file" = Get-Item -Path $FilePath
+            "ref"  = (Get-Item -Path $FilePath).Name
+            "purpose" = 'image'
+        }
+        "WebSession" = $ghostSession
     }
     
-    Invoke-RestMethod @invParams
+    Invoke-RestMethod @Params
 }
-


### PR DESCRIPTION
This utilizes the Form Data component introduced in PS Core 6.1.0. This allows you to mimic similar curl functionality. The only key is that you have to allow "application/octet-stream" in the uploads mime types to Ghost. I don't yet have a way to change that as PowerShell sends the data over that way instead of allowing you to specify that specifically.